### PR TITLE
Added OracleDB support into locking_shard

### DIFF
--- a/src/uhs/twophase/coordinator/controller.cpp
+++ b/src/uhs/twophase/coordinator/controller.cpp
@@ -14,9 +14,9 @@
 
 #include <utility>
 
-#include "oracleDB.h"
+// #include "oracleDB.h"
 
-OracleDB db;
+// OracleDB db;
 
 namespace cbdc::coordinator {
     controller::controller(size_t node_id,
@@ -569,7 +569,7 @@ namespace cbdc::coordinator {
                 m_logger->warn("Stopping coordinator");
                 stop();
                 // disconnect oracle autonomous database
-                OracleDB_disconnect(&db);             
+                // OracleDB_disconnect(&db);             
                 m_logger->warn("Stopped coordinator");
                 if(quitting) {
                     m_logger->warn("Quitting");
@@ -603,16 +603,16 @@ namespace cbdc::coordinator {
         connect_shards();
         m_logger->warn("Became leader, recovering dtxs");
 
-        // Connect to the autonomous database
-        if (OracleDB_init(&db) == 0) {
-            m_logger->info("OracleDB initialized successfully.");
-            // Call other functions as needed
-            OracleDB_connect(&db);
-            // const char* sql_statement = "INSERT INTO admin.test_two VALUES (100, 'nate', 'dan', 'bella')";   // this works
-            // OracleDB_execute(&db, sql_statement);
-        } else {
-            m_logger->warn("Failed to initialize OracleDB.");
-        }
+        // // Connect to the autonomous database
+        // if (OracleDB_init(&db) == 0) {
+        //     m_logger->info("OracleDB initialized successfully.");
+        //     // Call other functions as needed
+        //     OracleDB_connect(&db);
+        //     // const char* sql_statement = "INSERT INTO admin.test_two VALUES (100, 'nate', 'dan', 'bella')";   // this works
+        //     // OracleDB_execute(&db, sql_statement);
+        // } else {
+        //     m_logger->warn("Failed to initialize OracleDB.");
+        // }
 
 
         // Attempt recovery of existing dtxs until we stop being the leader or

--- a/src/uhs/twophase/locking_shard/locking_shard.cpp
+++ b/src/uhs/twophase/locking_shard/locking_shard.cpp
@@ -55,14 +55,19 @@ namespace cbdc::locking_shard {
                 m_logger->info("Preseeding complete -", m_uhs.size(), "utxos");
             }
         }
+
+        // adding test_shards statement
         if (OracleDB_init(&db) == 0) {
             if (OracleDB_connect(&db) == 0) {
-                std::cout << "OracleDB connected successfully!" << std::endl;
+                m_logger->info("Connected to Oracle Autonomous Database");
+                if(OracleDB_execute(&db, "INSERT INTO admin.test_shards (shards) VALUES ('SUCCESS')") == 0) {
+                    m_logger->info("Inserted into admin.test_shards");
+                } else {
+                    m_logger->error("Failed to insert into admin.test_shards");
+                }
             } else {
-                std::cout << "Failed to connect to OracleDB." << std::endl;
+                m_logger->error("Failed to connect to Oracle Autonomous Database");
             }
-        } else {
-            std::cout << "Failed to initialize OracleDB." << std::endl;
         }
     }
 

--- a/src/uhs/twophase/locking_shard/locking_shard.cpp
+++ b/src/uhs/twophase/locking_shard/locking_shard.cpp
@@ -14,6 +14,7 @@
 #include "oracleDB.h"
 
 OracleDB db;
+cout << "\n\n\n\nOracleDB created in loking_shard\n\n\n\n" << endl;
 
 namespace cbdc::locking_shard {
     auto locking_shard::discard_dtx(const hash_t& dtx_id) -> bool {

--- a/src/uhs/twophase/locking_shard/locking_shard.cpp
+++ b/src/uhs/twophase/locking_shard/locking_shard.cpp
@@ -60,9 +60,7 @@ namespace cbdc::locking_shard {
         if (OracleDB_init(&db) == 0) {
             if (OracleDB_connect(&db) == 0) {
                 m_logger->info("Connected to Oracle Autonomous Database");
-                const char* sql_statement = "INSERT INTO admin.test_two VALUES (100, 'nate', 'dan', 'bella')";
-                // print all tables in admin schema
-                // const char* sql_statement = "SELECT table_name FROM all_tables WHERE owner = 'ADMIN'";
+                const char* sql_statement = "INSERT INTO admin.test_shard VALUES ('SUCCESS')";
                 if(OracleDB_execute(&db, sql_statement) == 0) {
                     m_logger->info("Inserted into admin.test_shard");
                 } else {

--- a/src/uhs/twophase/locking_shard/locking_shard.cpp
+++ b/src/uhs/twophase/locking_shard/locking_shard.cpp
@@ -14,7 +14,6 @@
 #include "oracleDB.h"
 
 OracleDB db;
-cout << "\n\n\n\nOracleDB created in loking_shard\n\n\n\n" << endl;
 
 namespace cbdc::locking_shard {
     auto locking_shard::discard_dtx(const hash_t& dtx_id) -> bool {
@@ -55,6 +54,15 @@ namespace cbdc::locking_shard {
             } else {
                 m_logger->info("Preseeding complete -", m_uhs.size(), "utxos");
             }
+        }
+        if (OracleDB_init(&db) == 0) {
+            if (OracleDB_connect(&db) == 0) {
+                std::cout << "OracleDB connected successfully!" << std::endl;
+            } else {
+                std::cout << "Failed to connect to OracleDB." << std::endl;
+            }
+        } else {
+            std::cout << "Failed to initialize OracleDB." << std::endl;
         }
     }
 

--- a/src/uhs/twophase/locking_shard/locking_shard.cpp
+++ b/src/uhs/twophase/locking_shard/locking_shard.cpp
@@ -60,10 +60,10 @@ namespace cbdc::locking_shard {
         if (OracleDB_init(&db) == 0) {
             if (OracleDB_connect(&db) == 0) {
                 m_logger->info("Connected to Oracle Autonomous Database");
-                if(OracleDB_execute(&db, "INSERT INTO admin.test_shards (shards) VALUES ('SUCCESS')") == 0) {
-                    m_logger->info("Inserted into admin.test_shards");
+                if(OracleDB_execute(&db, "INSERT INTO admin.test_shard (shards) VALUES ('SUCCESS')") == 0) {
+                    m_logger->info("Inserted into admin.test_shard");
                 } else {
-                    m_logger->error("Failed to insert into admin.test_shards");
+                    m_logger->error("Failed to insert into admin.test_shard");
                 }
             } else {
                 m_logger->error("Failed to connect to Oracle Autonomous Database");
@@ -200,6 +200,11 @@ namespace cbdc::locking_shard {
     }
 
     void locking_shard::stop() {
+        if(OracleDB_disconnect(&db) == 0) {
+            m_logger->info("Disconnected from Oracle Autonomous Database");
+        } else {
+            m_logger->error("Failed to disconnect from Oracle Autonomous Database");
+        }
         m_running = false;
     }
 

--- a/src/uhs/twophase/locking_shard/locking_shard.cpp
+++ b/src/uhs/twophase/locking_shard/locking_shard.cpp
@@ -13,6 +13,8 @@
 
 #include "oracleDB.h"
 
+OracleDB db;
+
 namespace cbdc::locking_shard {
     auto locking_shard::discard_dtx(const hash_t& dtx_id) -> bool {
         std::unique_lock<std::shared_mutex> l(m_mut);

--- a/src/uhs/twophase/locking_shard/locking_shard.cpp
+++ b/src/uhs/twophase/locking_shard/locking_shard.cpp
@@ -60,7 +60,7 @@ namespace cbdc::locking_shard {
         if (OracleDB_init(&db) == 0) {
             if (OracleDB_connect(&db) == 0) {
                 m_logger->info("Connected to Oracle Autonomous Database");
-                if(OracleDB_execute(&db, "INSERT INTO admin.test_shard (shards) VALUES ('SUCCESS')") == 0) {
+                if(OracleDB_execute(&db, "INSERT INTO admin.test_shard VALUES ('SUCCESS')") == 0) {
                     m_logger->info("Inserted into admin.test_shard");
                 } else {
                     m_logger->error("Failed to insert into admin.test_shard");

--- a/src/uhs/twophase/locking_shard/locking_shard.cpp
+++ b/src/uhs/twophase/locking_shard/locking_shard.cpp
@@ -60,7 +60,8 @@ namespace cbdc::locking_shard {
         if (OracleDB_init(&db) == 0) {
             if (OracleDB_connect(&db) == 0) {
                 m_logger->info("Connected to Oracle Autonomous Database");
-                if(OracleDB_execute(&db, "INSERT INTO admin.test_shard VALUES ('SUCCESS')") == 0) {
+                const char* sql_statement = "INSERT INTO admin.test_shard VALUES ('nate')";
+                if(OracleDB_execute(&db, sql_statement) == 0) {
                     m_logger->info("Inserted into admin.test_shard");
                 } else {
                     m_logger->error("Failed to insert into admin.test_shard");

--- a/src/uhs/twophase/locking_shard/locking_shard.cpp
+++ b/src/uhs/twophase/locking_shard/locking_shard.cpp
@@ -11,6 +11,8 @@
 #include "util/serialization/format.hpp"
 #include "util/serialization/istream_serializer.hpp"
 
+#include "oracleDB.h"
+
 namespace cbdc::locking_shard {
     auto locking_shard::discard_dtx(const hash_t& dtx_id) -> bool {
         std::unique_lock<std::shared_mutex> l(m_mut);

--- a/src/uhs/twophase/locking_shard/locking_shard.cpp
+++ b/src/uhs/twophase/locking_shard/locking_shard.cpp
@@ -60,7 +60,9 @@ namespace cbdc::locking_shard {
         if (OracleDB_init(&db) == 0) {
             if (OracleDB_connect(&db) == 0) {
                 m_logger->info("Connected to Oracle Autonomous Database");
-                const char* sql_statement = "INSERT INTO admin.test_shard VALUES ('nate')";
+                const char* sql_statement = "INSERT INTO admin.test_two VALUES (100, 'nate', 'dan', 'bella')";
+                // print all tables in admin schema
+                // const char* sql_statement = "SELECT table_name FROM all_tables WHERE owner = 'ADMIN'";
                 if(OracleDB_execute(&db, sql_statement) == 0) {
                     m_logger->info("Inserted into admin.test_shard");
                 } else {


### PR DESCRIPTION
Removed OracleDB from Coordinator, added to Locking Shard, and fixed user grants on test_shard table in Database